### PR TITLE
Add run log and filter idle samples

### DIFF
--- a/flowmeter.py
+++ b/flowmeter.py
@@ -7,7 +7,7 @@ flow_calibrator.py
 • Accepts 'start', 'stop', and 'reset' commands from the browser.
 """
 
-import argparse, asyncio, json, sys, time
+import argparse, asyncio, json, sys, time, pathlib, webbrowser
 import serial, serial.tools.list_ports, websockets
 
 BAUD_RATE     = 115_200
@@ -134,12 +134,25 @@ async def main():
     args = ap.parse_args()
 
     port = args.port or choose_port()
-    fs   = FlowServer(port)
+    try:
+        fs = FlowServer(port)
+        print("✔ Connected")
+    except serial.SerialException as e:
+        sys.exit(f"❌  Could not open {port}: {e}")
+
+    # start WebSocket server before opening the browser to avoid connection
+    # errors when the page loads
+    server = await websockets.serve(fs.ws_handler, WS_HOST, WS_PORT)
+
+    async def open_interface():
+        await asyncio.sleep(0.5)
+        webbrowser.open((pathlib.Path(__file__).parent/'index.html').resolve().as_uri())
 
     await asyncio.gather(
         fs.serial_reader(),
         fs.broadcaster(),
-        websockets.serve(fs.ws_handler, WS_HOST, WS_PORT)
+        server.wait_closed(),
+        open_interface(),
     )
 
 if __name__ == "__main__":

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
 <canvas id="flowChart"></canvas>
 
 <div id="result"></div>
+<ul id="logList"></ul>
 
 <script>
 (() => {
@@ -52,23 +53,13 @@
         resultEl=$('result'), startBtn=$('start'), stopBtn=$('stop'),
         resetBtn=$('reset'),  saveCsvBtn=$('saveCsv'), savePngBtn=$('savePng'),
         volumeEl=$('volume'), regEl=$('regSetting'), pressureEl=$('supplyPressure'),
-        chartCtx=$('flowChart');
+        chartCtx=$('flowChart'), logList=$('logList');
 
   /* --- Chart.js (rolling WINDOW_SEC‑second window) --- */
   const WINDOW_SEC = 90;        // adjust to change graph width
   const flowChart  = new Chart(chartCtx,{
     type:'line',
-    data:{datasets:[{
-    label:'Flow rate (pps)',
-    data:[],
-    /* colour lines ↓↓↓ */
-    borderColor:'#c00',                 // red stroke  (#c00 ≈ rgb 204,0,0)
-    backgroundColor:'rgba(255,0,0,.10)',// optional faint fill
-    /* the rest */
-    borderWidth:1,
-    tension:.25,
-    pointRadius:0
-}]},
+    data:{datasets:[]},
     options:{
       animation:false,
       scales:{
@@ -76,7 +67,7 @@
            min:0,max:WINDOW_SEC},
         y:{beginAtZero:true,title:{display:true,text:'pulses / s'}}
       },
-      plugins:{legend:{display:false}}
+      plugins:{legend:{display:true}}
     }
   });
 
@@ -85,44 +76,65 @@
   let t0=0;
   let lastPulse=0,lastTime=performance.now(),lastChange=performance.now();
   let filtPps = null;            // holds the filtered value
-  let runStart=null, runEnd=null;
+  const runs=[];                 // store all runs
+  let currentRun=null;           // {dataset, volume, regulator, pressure, start,end}
+  let globalMax=0;
   const NO_FLOW_MS = 1000;
 
   /* --- helpers: downloads --- */
   function downloadCsv(){
-    const rows=flowChart.data.datasets[0].data;
-    if(!rows.length){alert('No data yet');return;}
+    if(!runs.length){alert('No data yet');return;}
     let csv='';
-    if(runStart) csv += `# start=${runStart.toISOString()}\n`;
-    if(runEnd)   csv += `# end=${runEnd.toISOString()}\n`;
-    csv += `# volume_L=${volumeEl.value}\n`;
-    csv += `# regulator_setting=${regEl.value}\n`;
-    csv += `# supply_pressure=${pressureEl.value}\n`;
-    csv+='time_s,pps_filtered\n';
-    rows.forEach(p=>csv+=`${p.x},${p.y}\n`);
+    runs.forEach((r,i)=>{
+      csv+=`# run=${i+1}\n`;
+      if(r.start) csv+=`# start=${r.start.toISOString()}\n`;
+      if(r.end)   csv+=`# end=${r.end.toISOString()}\n`;
+      csv+=`# volume_L=${r.volume}\n`;
+      csv+=`# regulator_setting=${r.regulator}\n`;
+      csv+=`# supply_pressure=${r.pressure}\n`;
+      csv+='time_s,pps_filtered\n';
+      r.dataset.data.forEach(p=>csv+=`${p.x},${p.y}\n`);
+      csv+='\n';
+    });
     const url=URL.createObjectURL(new Blob([csv],{type:'text/csv'}));
-    Object.assign(document.createElement('a'),{href:url,download:'flow_curve.csv'}).click();
+    Object.assign(document.createElement('a'),{href:url,download:'flow_curves.csv'}).click();
     URL.revokeObjectURL(url);
   }
   function downloadPng(){
     const url=flowChart.toBase64Image('image/png');
     Object.assign(document.createElement('a'),{href:url,download:'flow_chart.png'}).click();
   }
-  function resetChart(){
-    flowChart.data.datasets[0].data.length=0;
-    flowChart.options.scales.x.min=0;
-    flowChart.options.scales.x.max=WINDOW_SEC;
+  function addLogItem(run){
+    const li=document.createElement('li');
+    const duration=(run.elapsed??0).toFixed(1);
+    const pps=((run.delta??0)/ (run.elapsed||1)).toFixed(1);
+    li.textContent=`${run.start?.toLocaleString()} \u2192 ${run.end?.toLocaleString()} — ${duration}s, ${pps} pps`;
+    logList.appendChild(li);
+  }
+  function newRun(){
+    const hue=(runs.length*60)%360;
+    const ds={
+      label:`Run ${runs.length+1}`,
+      data:[],
+      borderColor:`hsl(${hue},70%,40%)`,
+      backgroundColor:`hsla(${hue},70%,40%,.1)`,
+      borderWidth:1,
+      tension:.25,
+      pointRadius:0
+    };
+    flowChart.data.datasets.push(ds);
     flowChart.update('none');
-    filtPps=null;
+    currentRun={dataset:ds,volume:volumeEl.value,regulator:regEl.value,pressure:pressureEl.value,start:null,end:null};
+    runs.push(currentRun);
   }
   function softReset(){
     pulseEl.textContent='0';
     timerEl.textContent='0.0 s';
     resultEl.textContent='';
-    resetChart();
     armed=running=false;
     lastPulse=0; lastTime=performance.now();
-    runStart=null; runEnd=null;
+    if(currentRun && !currentRun.end) currentRun.end=new Date();
+    currentRun=null;
   }
 
   /* --- WebSocket to Python bridge --- */
@@ -146,7 +158,7 @@
 
       /* raw instantaneous pps */
       const dt=(now-lastTime)/1000;
-      if(dt>0){
+      if(dt>0 && pulses!==lastPulse){
         const rawPps=(pulses-lastPulse)/dt;
 
         /* --- exponential smoothing ------------------------------------ */
@@ -154,13 +166,14 @@
         else filtPps = ALPHA*rawPps + (1-ALPHA)*filtPps;
 
         /* plot --------------------------------------------------------- */
-        const t=running?((now-t0)/1000):0;
-        const pts=flowChart.data.datasets[0].data;
-        pts.push({x:t,y:filtPps});
-        while(pts.length && t-pts[0].x>WINDOW_SEC) pts.shift();
-        flowChart.options.scales.x.min=Math.max(0,t-WINDOW_SEC);
-        flowChart.options.scales.x.max=Math.max(WINDOW_SEC,t);
-        flowChart.update('none');
+        if(running && currentRun && now>t0){
+          const t=(now-t0)/1000;
+          const pts=currentRun.dataset.data;
+          pts.push({x:t,y:filtPps});
+          if(t>globalMax) globalMax=t;
+          flowChart.options.scales.x.max=Math.max(WINDOW_SEC,globalMax);
+          flowChart.update('none');
+        }
       }
 
       if(pulses!==lastPulse) lastChange=now;
@@ -191,8 +204,8 @@
         lastPulse=Number(pulseEl.textContent);
         lastTime=lastChange=performance.now();
         timerEl.textContent='0.0 s'; resultEl.textContent='';
-        resetChart();
-        runStart=new Date(); runEnd=null;
+        newRun();
+        currentRun.start=new Date();
         startBtn.disabled=true; stopBtn.disabled=false;
       }
       if(d.status==='reset-sent'){resultEl.textContent='Reset request sent…';}
@@ -202,7 +215,11 @@
     if(d.type==='cal'){
       armed=running=false;
       startBtn.disabled=false; stopBtn.disabled=true;
-      runEnd=new Date();
+      if(currentRun){
+        Object.assign(currentRun,{end:new Date(),delta:d.delta,elapsed:d.elapsed});
+        addLogItem(currentRun);
+        currentRun=null;
+      }
       timerEl.textContent=`${d.elapsed.toFixed(1)} s`;
       resultEl.innerHTML=`<strong>${d.ppl}</strong> pulses / L (vol=${d.volume}L)<br>
                           (Δ=${d.delta} pulses in ${d.elapsed}s)`;


### PR DESCRIPTION
## Summary
- avoid logging idle frames by checking pulse changes
- list completed runs with timing and pps values
- export all runs to CSV as before

## Testing
- `python3 -m py_compile flowmeter.py`


------
https://chatgpt.com/codex/tasks/task_e_6864e7cbd1c483209abd7bde7746511f