### PR TITLE
Reset lastPulse when start acknowledged

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,7 @@
         if(d.status==='started'){
           armed=true; running=false; startPending=true;
           lastTime=lastChange=performance.now();
+          lastPulse=0;
           timerEl.textContent='0.0 s'; resultEl.textContent='';
           startBtn.disabled=true; stopBtn.disabled=false;
         }


### PR DESCRIPTION
## Summary
- reset the `lastPulse` counter when a start is acknowledged

## Testing
- `python3 -m py_compile flowmeter.py`

------
https://chatgpt.com/codex/tasks/task_e_6865008424d483209c09cbae75baba0b