### PR TITLE
Refine pressure calibration and layout

### DIFF
--- a/Flowmeter/Flowmeter.ino
+++ b/Flowmeter/Flowmeter.ino
@@ -19,9 +19,9 @@ const unsigned long BAUD  = 115200;
 // smoothing a little on the ESP8266 side.
 const unsigned long INTERVAL_MS = 150;  // how often to send a CSV frame
 
-const float    PFS_OUT     = 0.75f * 0.980f;           // ITV-313L full-scale (MPa)
-const int ADC_ZERO = 198;
-const float ADC_MPA_PER_COUNT = 0.45f / (580.0f - 198.0f); // 0.00118
+const float    PFS_OUT     = 0.75f * 0.980f * 0.996f * 0.957f;           // ITV-313L full-scale (MPa)
+const int ADC_ZERO = 202;
+const float ADC_MPA_PER_COUNT = 0.001176f;
 const uint8_t  PWM_PIN = D5;             // GP8101S control (0-10 V)
 const uint8_t PWM_MAX = 255;
 volatile int   setpoint_mbar = 0;

--- a/flowmeter.py
+++ b/flowmeter.py
@@ -289,9 +289,11 @@ class FlowServer:
                     self.target_weight = (
                         float(weight_val) if isinstance(weight_val, (int, float)) and weight_val > 0 else None
                     )
-                    self.target_seconds = (
-                        float(seconds_val) if isinstance(seconds_val, (int, float)) and seconds_val > 0 else None
-                    )
+                    try:
+                        seconds_f = float(seconds_val)
+                    except (TypeError, ValueError):
+                        seconds_f = None
+                    self.target_seconds = seconds_f if seconds_f and seconds_f > 0 else None
                     await ws.send(json.dumps({"type":"ack","status":"started"}))
 
                 # ---- stop calibration ----

--- a/index.html
+++ b/index.html
@@ -77,12 +77,14 @@
   <div class="grid grid-cols-2 gap-4 place-items-center text-center max-w-md w-full mx-auto px-4" id="params">
   <div>Regulator version <input id="reg" type="text" class="border rounded px-2 w-24"></div>
   <div id="voltRange">Voltage range <span id="voltStart">0.00</span>→<span id="voltEnd">0.00</span> V</div>
-  <div>End pressure (MPa) <input id="pressEnd" type="number" step="0.01" min="0" max="0.9" class="border rounded px-2 w-24"></div>
   <div>Start pressure (MPa) <input id="pressStart" type="number" step="0.01" min="0" max="0.9" class="border rounded px-2 w-24"></div>
+  <div>End pressure (MPa) <input id="pressEnd" type="number" step="0.01" min="0" max="0.9" class="border rounded px-2 w-24"></div>
   <div id="limitPulse">Stop after pulses <input id="targetP" type="number" min="1" step="1" class="border rounded px-2 w-24"></div>
   <div id="limitWeight" class="hidden">Stop at weight (g) <input id="targetW" type="number" min="1" step="1" class="border rounded px-2 w-24"></div>
-  <div>Stop after seconds <input id="targetS" type="number" min="1" step="1" class="border rounded px-2 w-24"></div>
+  <div>Stop after seconds <input id="targetS" type="number" min="1" max="3600" step="1" class="border rounded px-2 w-24"></div>
+  <div></div>
   <div id="autoBox"><label class="inline-flex items-center"><input id="autoStop" type="checkbox" class="mr-2" checked> auto-stop when value stops changing</label></div>
+  <label class="inline-flex items-center"><input id="interp" type="checkbox" class="mr-2"> Interpolate</label>
 </div>
 
 <button id="start" disabled class="px-4 py-2 text-base bg-blue-500 text-white rounded hover:bg-blue-600 transition disabled:opacity-50 disabled:cursor-not-allowed">Start</button>
@@ -93,8 +95,6 @@
 <button id="savePng" disabled class="px-4 py-2 text-base bg-blue-500 text-white rounded hover:bg-blue-600 transition disabled:opacity-50 disabled:cursor-not-allowed">Save PNG</button>
 
 <div id="chart" class="mx-auto w-11/12 max-w-[700px] mt-4 border border-gray-300 p-4"></div>
-
-<label class="block mt-2"><input id="interp" type="checkbox" class="mr-2"> Interpolate</label>
 
 <div id="result" class="mt-4 text-green-700"></div>
 <ul id="log" class="mt-4 space-y-1"></ul>
@@ -194,7 +194,13 @@
     const shape = interpEl.checked ? 'spline' : 'linear';
     const idxs = Array.from({length: chartDiv.data.length}, (_, i) => i);
     Plotly.restyle(chartDiv, { 'line.shape': shape }, idxs);
-    runs.forEach(r => { if (r.trace.line) r.trace.line.shape = shape; });
+    runs.forEach(r => {
+      if (r.trace.line) r.trace.line.shape = shape;
+      if (r.fitTrace) {
+        r.fitTrace.line.shape = 'linear';
+        Plotly.restyle(chartDiv, { 'line.shape': 'linear' }, [r.fitIdx]);
+      }
+    });
   };
   function updateVolt(){
     const ps=parseFloat(pressStartEl.value);
@@ -333,6 +339,7 @@
 
       if(running){
         const t=(now-t0)/1000;
+        if(t>xMax){ xMax=t; Plotly.relayout(chartDiv,{"xaxis.range":[0,Math.max(30,xMax)]}); }
         if(d.pressure!=null) Plotly.extendTraces(chartDiv,{x:[[t]],y:[[d.pressure]]},[PRESS_TRACE_IDX]);
         if(d.pCmd!=null) Plotly.extendTraces(chartDiv,{x:[[t]],y:[[d.pCmd]]},[DES_TRACE_IDX]);
       }
@@ -390,7 +397,12 @@
       stopBtn.disabled=true;
       beep(500,300);
       elapsedEl.textContent=d.elapsed.toFixed(1)+' s';
-      if(current){ Object.assign(current,{end:new Date(),delta:d.delta,elapsed:d.elapsed,pps:d.pps,rate:d.rate,sensor:d.sensor,endPressure:d.endP,startPressure:d.startP}); addLog(current); current=null; }
+      if(current){
+        Object.assign(current,{end:new Date(),delta:d.delta,elapsed:d.elapsed,pps:d.pps,rate:d.rate,sensor:d.sensor,endPressure:d.endP,startPressure:d.startP});
+        addLog(current);
+        addFit(current);
+        current=null;
+      }
       if(d.sensor==='scale'){ resultEl.textContent=(d.rate/1000).toFixed(3)+' L/s'; }
       else { resultEl.textContent=d.pps+' pps'; }
     }
@@ -402,6 +414,50 @@
     current.trace.customdata.push([lastCmd,lastPress]);
     if(t>xMax){ xMax=t; Plotly.relayout(chartDiv,{"xaxis.range":[0,Math.max(30,xMax)]}); }
     Plotly.extendTraces(chartDiv,{x:[[t]],y:[[y]],customdata:[[[lastCmd,lastPress]]]},[current.idx]);
+  }
+
+  function rdp(points, epsilon){
+    const dist = (p, a, b) => {
+      const num = Math.abs((b.y - a.y) * p.x - (b.x - a.x) * p.y + b.x * a.y - b.y * a.x);
+      const den = Math.hypot(b.y - a.y, b.x - a.x);
+      return den ? num / den : 0;
+    };
+    function simplify(pts){
+      if(pts.length < 3) return pts;
+      let dmax = 0, idx = 0;
+      const start = pts[0], end = pts[pts.length-1];
+      for(let i=1;i<pts.length-1;i++){
+        const d = dist(pts[i], start, end);
+        if(d > dmax){ idx = i; dmax = d; }
+      }
+      if(dmax > epsilon){
+        const res1 = simplify(pts.slice(0, idx+1));
+        const res2 = simplify(pts.slice(idx));
+        return res1.slice(0,-1).concat(res2);
+      } else {
+        return [start, end];
+      }
+    }
+    return simplify(points);
+  }
+
+  function addFit(r){
+    const pts = r.trace.x.map((x,i)=>({x:x, y:r.trace.y[i]}));
+    const eps = r.sensor==='flow' ? 0.5 : 0.005;
+    const simp = rdp(pts, eps);
+    const fx = simp.map(p=>p.x);
+    const fy = simp.map(p=>p.y);
+    const trace = {
+      x: fx,
+      y: fy,
+      mode:'lines',
+      line:{color:r.trace.line.color, dash:'dot', shape:'linear'},
+      name: r.trace.name+' fit',
+      hoverinfo:'skip'
+    };
+    Plotly.addTraces(chartDiv, trace);
+    r.fitIdx = chartDiv.data.length-1;
+    r.fitTrace = trace;
   }
   function newRun(){
     const hue=(runs.length*60)%360;
@@ -418,7 +474,7 @@
         : `${name}<br>%{y:.1f} pps at %{x:.1f}s<br>Desired %{customdata[0]:.3f} MPa<br>Actual %{customdata[1]:.3f} MPa<extra></extra>`
     };
     Plotly.addTraces(chartDiv, trace);
-    current={idx:chartDiv.data.length-1, trace:trace, sensor:sensor, volume:VOLUME_L, regulator:regEl.value, startPressure:pressStartEl.value?Number(pressStartEl.value):0, endPressure:pressEndEl.value?Number(pressEndEl.value):0, startVoltage:voltStartEl.textContent, endVoltage:voltEndEl.textContent, start:new Date(), end:null, cmd:[], act:[], volt:[]};
+    current={idx:chartDiv.data.length-1, fitIdx:null, trace:trace, fitTrace:null, sensor:sensor, volume:VOLUME_L, regulator:regEl.value, startPressure:pressStartEl.value?Number(pressStartEl.value):0, endPressure:pressEndEl.value?Number(pressEndEl.value):0, startVoltage:voltStartEl.textContent, endVoltage:voltEndEl.textContent, start:new Date(), end:null, cmd:[], act:[], volt:[]};
     runs.push(current);
   }
   function addLog(r){
@@ -440,18 +496,21 @@
   function removeRun(r){
     const idx=runs.indexOf(r);
     if(idx===-1) return;
-    Plotly.deleteTraces(chartDiv,[r.idx]);
+    Plotly.deleteTraces(chartDiv,[r.idx, r.fitIdx].sort((a,b)=>a-b));
     runs.splice(idx,1);
     if(r.li) r.li.remove();
     runs.forEach((run,i)=>{
-      run.idx=i+2;
+      run.idx = 2 + i*2;
+      run.fitIdx = run.idx + 1;
       const name=`Run ${i+1}: ${run.regulator||'n/a'} — ${(run.startPressure||0).toFixed(3)}→${(run.endPressure||0).toFixed(3)} MPa`;
       run.trace.name=name;
       run.trace.hovertemplate=run.sensor==='scale'
         ? `${name}<br>%{y:.3f} L/s at %{x:.1f}s<br>Desired %{customdata[0]:.3f} MPa<br>Actual %{customdata[1]:.3f} MPa<extra></extra>`
         : `${name}<br>%{y:.1f} pps at %{x:.1f}s<br>Desired %{customdata[0]:.3f} MPa<br>Actual %{customdata[1]:.3f} MPa<extra></extra>`;
       run.trace.line.shape = interpEl.checked?'spline':'linear';
-      Plotly.restyle(chartDiv,{name:run.trace.name,hovertemplate:run.trace.hovertemplate,"line.shape":run.trace.line.shape},[i+2]);
+      run.fitTrace.name = name+' fit';
+      Plotly.restyle(chartDiv,{name:run.trace.name,hovertemplate:run.trace.hovertemplate,"line.shape":run.trace.line.shape},[run.idx]);
+      Plotly.restyle(chartDiv,{name:run.fitTrace.name,"line.shape":'linear'},[run.fitIdx]);
     });
   }
 


### PR DESCRIPTION
## Summary
- Allow longer timed runs and parse seconds robustly
- Overlay piecewise-linear fits on flow/weight curves for clearer trends

## Testing
- `python -m py_compile flowmeter.py`


------
https://chatgpt.com/codex/tasks/task_e_689215758a3c83209329b0fa8e0e0c07